### PR TITLE
If venv is activate, choose install location accordingly.

### DIFF
--- a/webdriverdownloader/webdriverdownloader.py
+++ b/webdriverdownloader/webdriverdownloader.py
@@ -41,7 +41,11 @@ class WebDriverDownloaderBase:
         if platform.system() in ['Darwin', 'Linux'] and os.geteuid() == 0:
             base_path = "/usr/local"
         else:
-            base_path = os.path.expanduser("~")
+            if 'VIRTUAL_ENV' in os.environ:
+                base_path = os.environ['VIRTUAL_ENV']
+            else:
+                base_path = os.path.expanduser("~")
+
 
         if download_root is None:
             self.download_root = os.path.join(base_path, "webdriver")
@@ -49,7 +53,10 @@ class WebDriverDownloaderBase:
             self.download_root = download_root
 
         if link_path is None:
-            self.link_path = os.path.join(base_path, "bin")
+            bin_location = "bin"
+            if 'VIRTUAL_ENV' in os.environ and platform.system() == "Windows":
+                bin_location = "Scripts"
+            self.link_path = os.path.join(base_path, bin_location)
         else:
             self.link_path = link_path
 


### PR DESCRIPTION
When running things in CI environments, one might not have access to write things outside of the workspace so quite often people resort to virtualenv.  When venv is activated, there's VIRTUAL_ENV environment variable which tells the base path where things can be installed.  If that variable is set (eg, venv is active), this patch uses that directory to download the webdriver and install the binary/link into correct location within the provided virtual env. Covers also windows side but its untested atm as i dont have access to windows box. Venv in windows doesnt install executables to "bin" but to "Scripts" folder .. 