### PR TITLE
fixed bug to download geckodriver on linux 64bit

### DIFF
--- a/webdriverdownloader/webdriverdownloader.py
+++ b/webdriverdownloader/webdriverdownloader.py
@@ -317,7 +317,7 @@ class GeckoDriverDownloader(WebDriverDownloaderBase):
             logger.error(info_message)
             raise RuntimeError(info_message)
         if len(filename) > 1:
-            filename = [name for name in filenames if os_name + bitness in name]
+            filename = [name for name in filenames if os_name + bitness in name and name[-3:] != 'asc' ]
             if len(filename) != 1:
                 info_message = "Error, unable to determine correct filename for {0}bit {1}".format(bitness, os_name)
                 logger.error(info_message)


### PR DESCRIPTION
So, Even after filtering for the filenames wich matches linux os and that are 64 bit, the list filename still had 2 elements on it.

One was something like 'geckodriver-version.tar.gz' and the other was 'geckodriver-version.tar.gz.asc'

So this was making me fall into that exception 

`if len(filename) != 1:
                info_message = "Error, unable to determine correct filename for {0}bit {1}".format(bitness, os_name)
                logger.error(info_message)`

So i just added this filtering to remove anything ending in asc from the filename list. Looks like it should be consistent